### PR TITLE
feat: allow descriptions for menu categories and subcategories

### DIFF
--- a/data.js
+++ b/data.js
@@ -1,38 +1,42 @@
 const menuData = {
   "Chopchop": {
     "Comidas": {
-      "Entradas": [
-        {
-          "nombre": "Lengua a la vinagreta",
-          "detalle": "",
-          "precio": "7200"
-        },
-        {
-          "nombre": "Revuelto gramajo",
-          "detalle": "con jamón, queso y arvejas",
-          "precio": "9000"
-        },
-        {
-          "nombre": "Jamón Crudo",
-          "detalle": "",
-          "precio": "9200"
-        },
-        {
-          "nombre": "Tirolé Mixto",
-          "detalle": "de jamón, queso, mix de aceitunas",
-          "precio": "6000"
-        },
-        {
-          "nombre": "Tortilla de papa y cebolla",
-          "detalle": "para 2",
-          "precio": "9000"
-        },
-        {
-          "nombre": "Buñuelos de jamón y doble queso",
-          "detalle": "",
-          "precio": "7500"
-        }
-      ],
+      "descripcion": "Opciones para compartir y disfrutar",
+      "Entradas": {
+        "descripcion": "Para comenzar la experiencia",
+        "productos": [
+          {
+            "nombre": "Lengua a la vinagreta",
+            "detalle": "",
+            "precio": "7200"
+          },
+          {
+            "nombre": "Revuelto gramajo",
+            "detalle": "con jamón, queso y arvejas",
+            "precio": "9000"
+          },
+          {
+            "nombre": "Jamón Crudo",
+            "detalle": "",
+            "precio": "9200"
+          },
+          {
+            "nombre": "Tirolé Mixto",
+            "detalle": "de jamón, queso, mix de aceitunas",
+            "precio": "6000"
+          },
+          {
+            "nombre": "Tortilla de papa y cebolla",
+            "detalle": "para 2",
+            "precio": "9000"
+          },
+          {
+            "nombre": "Buñuelos de jamón y doble queso",
+            "detalle": "",
+            "precio": "7500"
+          }
+        ]
+      },
       "Picadas": [
         {
           "nombre": "Picada de fiambres",

--- a/script.js
+++ b/script.js
@@ -280,6 +280,7 @@ function renderSubcategorias(local, cat, evitarScroll = false) {
 
   const subcats = menuData[local][cat];
   for (const sub in subcats) {
+    if (sub === "descripcion") continue;
     const subBtn = document.createElement("button");
     subBtn.textContent = sub;
     subBtn.onclick = () => {
@@ -458,6 +459,7 @@ function renderSecciones() {
     isFirst = false;
 
     for (const categoria in menuData[local]) {
+      const catData = menuData[local][categoria];
       const sectionCat = document.createElement("section");
       sectionCat.setAttribute("data-categoria", categoria);
       sectionCat.setAttribute("data-local", local);
@@ -473,15 +475,25 @@ function renderSecciones() {
       h3.innerHTML = `<span>${categoria}</span>`;
       sectionCat.appendChild(h3);
 
-      for (const subcategoria in menuData[local][categoria]) {
-        const productos = menuData[local][categoria][subcategoria];
+      if (catData.descripcion) {
+        const pDesc = document.createElement("p");
+        pDesc.classList.add("descripcion-categoria");
+        pDesc.textContent = catData.descripcion;
+        sectionCat.appendChild(pDesc);
+      }
+
+      for (const subcategoria in catData) {
+        if (subcategoria === "descripcion") continue;
+        const subData = catData[subcategoria];
+        const productos = Array.isArray(subData) ? subData : subData.productos || [];
+        const subDesc = Array.isArray(subData) ? "" : subData.descripcion || "";
 
         const sectionSub = document.createElement("section");
         sectionSub.setAttribute("data-subcategoria", subcategoria);
         sectionSub.dataset.local = local;
         sectionSub.dataset.categoria = categoria;
         sectionSub.classList.add("subcategoria-block");
-        
+
         const key = `${local}-${categoria}-${subcategoria}`;
         if (backgroundImages[key]) {
           const h4 = document.createElement("h4");
@@ -490,7 +502,16 @@ function renderSecciones() {
           h4.innerHTML = `<span>${subcategoria}</span>`;
           sectionSub.appendChild(h4);
         } else {
-          sectionSub.innerHTML = `<h4>${subcategoria}</h4>`;
+          const h4 = document.createElement("h4");
+          h4.textContent = subcategoria;
+          sectionSub.appendChild(h4);
+        }
+
+        if (subDesc) {
+          const pSub = document.createElement("p");
+          pSub.classList.add("descripcion-subcategoria");
+          pSub.textContent = subDesc;
+          sectionSub.appendChild(pSub);
         }
 
         productos.forEach((p) => {
@@ -504,7 +525,7 @@ function renderSecciones() {
               <div class="precio">$${p.precio}</div>
             </div>
           `;
-          
+
         });
 
         sectionCat.appendChild(sectionSub);

--- a/styles.css
+++ b/styles.css
@@ -177,6 +177,14 @@ h4 {
 }
 
 
+.descripcion-categoria,
+.descripcion-subcategoria {
+  font-size: 14px;
+  font-weight: 300;
+  margin: 10px 0;
+  text-align: center;
+}
+
 .precio {
   font-size: 18px;
   color: var(--color-primary);


### PR DESCRIPTION
## Summary
- allow categories and subcategories to define optional descriptions
- display descriptions in menu rendering
- style category and subcategory descriptions

## Testing
- `node --check script.js`
- `node --check data.js`


------
https://chatgpt.com/codex/tasks/task_e_6891533529b48329be74fc6ecf51e942